### PR TITLE
pre-create folder, new container behavior

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ ENV JAVA_TOOL_OPTIONS -Djava.awt.headless=true
 ENV PATH C:\\java\\1.8.0_91\\bin;C:\\Windows\\system32;C:\\Windows;
 
 # Copy and configure Jenkins
+RUN mkdir C:\jenkins
 COPY --from=builder C:/install/jenkins.war C:/jenkins/jenkins.war
 ENV JENKINS_HOME c:\\jenkins_home
 


### PR DESCRIPTION
For unknown reasons, the copy process has decided to halt if the folder is not pre-created when copying the jenkins.war (still works when copying a complete folder in the java step previous).

Added a new RUN statement to fix this.